### PR TITLE
Removed columns from FlatLists

### DIFF
--- a/app/(tabs)/activities.tsx
+++ b/app/(tabs)/activities.tsx
@@ -45,11 +45,11 @@ export default function ActivitiesScreen() {
   return (
     <ThemedView style={{ flex: 1, padding: 16 }}>
       {user ? (
-      <ThemedView style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
+      <ThemedView style={{ alignItems: 'center', marginBottom: 16 }}>
        <ThemedText type="title" style={{ marginRight: 8 }}>
           Recent Activities
         </ThemedText>
-        {month && <ThemedButton title="Show all activities" onPress={removeMonthFilter} />}
+        {month && <ThemedButton style={{ marginTop: 10 }} title="Show all activities" onPress={removeMonthFilter} />}
       </ThemedView>
       ) : (
 <>
@@ -78,13 +78,12 @@ export default function ActivitiesScreen() {
       )}
       <FlatList
         data={displayData}
-        key={`columns-${4}`}
-        numColumns={4}
+        key={`columns-${1}`}
+        numColumns={1}
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
           <ThemedView
           style={{
-            width: '22%',
             padding: 8,
             margin: '1%',
             borderRadius: 8,
@@ -99,9 +98,6 @@ export default function ActivitiesScreen() {
             <ThemedText>Elevation: {item.total_elevation_gain} m</ThemedText>
           </ThemedView>
         )}
-        columnWrapperStyle={{
-          justifyContent: 'flex-start',
-        }}
         />
     </ThemedView>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -32,10 +32,11 @@ function HomeScreen() {
         />
       }>
       {user ? (
-        <ThemedView style={styles.loggedInContainer}>
+        <ThemedView>
+          
           <View style={styles.userInfo}>
             <ThemedText type="title">Welcome back, {user.firstname}!</ThemedText>
-            <ThemedText type="subtitle">Let’s make today awesome!</ThemedText>
+            <ThemedText style={{marginTop:10}} type="subtitle">Let’s make today awesome!</ThemedText>
           </View>
 
           <View style={styles.dashboard}>
@@ -54,9 +55,7 @@ function HomeScreen() {
             <ThemedText>- Fixed bugs with Strava API sync.</ThemedText>
           </ThemedView>
 
-          <View style={styles.logOutButtonContainer}>
             <ThemedButton title="Log Out" onPress={handleLogOut} type="red" />
-          </View>
         </ThemedView>
       ) : (
         <>
@@ -102,43 +101,20 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
   },
-  loggedInContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 16,
-  },
   userInfo: {
     marginBottom: 16,
-    alignItems: 'center',
   },
-  logOutButtonContainer: {
-    position: 'absolute',
-    top: 16,
-    right: 16,
-  },dashboard: {
-    marginVertical: 16,
-    alignItems: 'center',
-  },
-  quickActions: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
+  dashboard: {
     marginVertical: 16,
   },
   quoteContainer: {
     marginVertical: 16,
-    alignItems: 'center',
   },
   updates: {
     marginVertical: 16,
     padding: 16,
     borderRadius: 8,
-  },
-  chart: {
-    marginVertical: 16,
-    alignSelf: 'stretch',
-    height: 200,
-  },
+  }
 });
 
 export default HomeScreen;

--- a/app/(tabs)/monthly_stats.tsx
+++ b/app/(tabs)/monthly_stats.tsx
@@ -86,29 +86,25 @@ export default function MonthlyStatsScreen() {
    
     <FlatList
   data={monthlyStats}
-  key={`columns-${3}`}
+  key={`columns-${1}`}
   keyExtractor={(item) => item.month.toString()}
-  numColumns={3}
+  numColumns={1}
   renderItem={({ item }) => (
     <ThemedView
       style={{
         padding: 8,
         margin: '1%',
-        width: '30%',
         borderRadius: 8,
         backgroundColor: colorScheme === 'dark' ? '#222222' : '#F0F4FF',
-        flexDirection: 'row', 
-        alignItems: 'flex-start',
+        alignItems: 'center',
         justifyContent: 'space-between', 
       }}
     >
-      {/* Left: Graph */}
       <SingleMonthChart
         singleMonthData={item}
         maxDistance={maxDistance}
       />
 
-      <View style={{ flex: 1, marginLeft: 20 }}>
         <ThemedText
           type="title"
           style={{
@@ -138,7 +134,6 @@ export default function MonthlyStatsScreen() {
         >
           View Activities
         </ThemedText>
-      </View>
     </ThemedView>
   )}
 />


### PR DESCRIPTION
I made a final adjustment to the Desktop CSS, which inadvertently affected the Phone CSS. The issue was caused by the fixed width and the 4 columns per row in the FlatLists, which disrupted the styling on the phone app. These issues have now been resolved.